### PR TITLE
Packages and config

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -1,0 +1,70 @@
+package conf
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config struct for our configuration settings
+type Config struct {
+	Loglevel string `yaml:"loglevel"`
+
+	Pfctl struct {
+		Enable bool   `yaml:"enable"`
+		Path   string `yaml:"path"`   // path for the pfctl binary default `/sbin/pfctl`
+		Suffix string `yaml:"suffix"` // suffix to use for client tables default `_clients`
+	} `yaml:"pfctl"`
+
+	Mysql struct {
+		Host       string `yaml:"host"` //protocol[(address)]
+		Username   string `yaml:"username"`
+		Password   string `yaml:"password"`
+		Database   string `yaml:"database"`
+		Properties string `yaml:"properties"`
+	} `yaml:"mysql"`
+
+	Memcache struct {
+		Host       string `yaml:"host"`     // Host:port or /var/run/...
+		Username   string `yaml:"username"` // These are not used currently
+		Password   string `yaml:"password"` // These are not used currently
+		Properties string `yaml:"properties"`
+	} `yaml:"memcache"`
+}
+
+// NewConfig returns a new decoded Config struct
+func NewConfig(configPath string) (*Config, error) {
+	// Create config structure
+	config := &Config{}
+
+	// Open config file
+	file, err := os.Open(configPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	// Init new YAML decode
+	d := yaml.NewDecoder(file)
+
+	// Start YAML decoding from file
+	if err := d.Decode(&config); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+// ValidateConfigPath just makes sure, that the path provided is a file,
+// that can be read
+func ValidateConfigPath(path string) error {
+	s, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if s.IsDir() {
+		return fmt.Errorf("'%s' is a directory, not a normal file", path)
+	}
+	return nil
+}

--- a/conf/env_init.go
+++ b/conf/env_init.go
@@ -14,11 +14,9 @@ type Environment struct {
 }
 
 func (env *Environment) Initialize() {
-	// Create config structure
-	//	env = &Environment{}
 	env.Mode = os.Getenv("script_type")
 	env.ID = os.Getenv("common_name")
 	env.LocalIP = os.Getenv("ifconfig_pool_remote_ip")
 	env.RemoteIP = os.Getenv("untrusted_ip")
-	log.Debugf("%v", env)
+	log.Debugf("Populated variable values: %v", env)
 }

--- a/conf/env_init.go
+++ b/conf/env_init.go
@@ -1,0 +1,24 @@
+package conf
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type Environment struct {
+	ID       string `json:"common_name"`
+	Mode     string `json:"script_type"`
+	LocalIP  string `json:"ifconfig_pool_remote_ip"`
+	RemoteIP string `json:"untrusted_ip"`
+}
+
+func (env *Environment) Initialize() {
+	// Create config structure
+	//	env = &Environment{}
+	env.Mode = os.Getenv("script_type")
+	env.ID = os.Getenv("common_name")
+	env.LocalIP = os.Getenv("ifconfig_pool_remote_ip")
+	env.RemoteIP = os.Getenv("untrusted_ip")
+	log.Debugf("%v", env)
+}

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,18 @@
+loglevel: debug
+pfctl:
+  enable: false
+  path: "/usr/sbin/pfctl"
+  suffix: "_clients"
+
+mysql:
+#  host: "tcp(127.0.0.1:3306)"
+  host: ""
+  username: root
+  password: ""
+  database: echoCTF
+  properties: ""
+#  properties: "param1=value1&...&paramN=valueN"
+# [username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]
+
+memcache:
+  host: "127.0.0.1:11211"

--- a/config.yml
+++ b/config.yml
@@ -5,14 +5,14 @@ pfctl:
   suffix: "_clients"
 
 mysql:
-#  host: "tcp(127.0.0.1:3306)"
   host: ""
+# Refer to the DSN connection string
+# https://github.com/go-sql-driver/mysql#dsn-data-source-name
+# host: "tcp(127.0.0.1:3306)"
+# properties: "param1=value1&...&paramN=valueN"
   username: root
   password: ""
   database: echoCTF
-  properties: ""
-#  properties: "param1=value1&...&paramN=valueN"
-# [username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]
 
 memcache:
   host: "127.0.0.1:11211"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module openvpn-updown
+module github.com/echoctf/openvpn-updown
 
 go 1.18
 


### PR DESCRIPTION
This PR introduces the following
* [x] Support for `-config` command line argument
* [x] support for parsing configuration file in YAML
* [x] Splits the configuration and initialization into `conf/` package
* [x] Introduces an EchoCTF struct that holds all our connections to important services (db, memcache, etc)
* [x] Renames the base module name to be the same as the repo `github.com/echoCTF/openvpn-updown`
* [x] Introduces an example config.yaml